### PR TITLE
Freq p stride size

### DIFF
--- a/profiling_container/syntetic/Makefile
+++ b/profiling_container/syntetic/Makefile
@@ -14,8 +14,8 @@ SNIPER_LIB = $(SNIPER_ROOT)/lib
 # -------------------------------------------------
 # Flags
 # -------------------------------------------------
-CFLAGS  = -g -O2 -Wall -fno-tree-vectorize -DENABLE_SNIPER \
-          -I$(SNIPER_INC)
+CFLAGS  = -g -O2 -Wall -fno-tree-vectorize -static \
+          -DENABLE_SNIPER -I$(SNIPER_INC)
 
 CFLAGS_O  = -g -O3 -march=native -funroll-loops -ftree-vectorize -ffast-math -ftree-vectorizer-verbose=2 -static \
            -DENABLE_SNIPER -I$(SNIPER_INC)

--- a/profiling_container/syntetic/Makefile
+++ b/profiling_container/syntetic/Makefile
@@ -17,8 +17,8 @@ SNIPER_LIB = $(SNIPER_ROOT)/lib
 CFLAGS  = -g -O2 -Wall -fno-tree-vectorize -DENABLE_SNIPER \
           -I$(SNIPER_INC)
 
-CFLAGS_O  = -g -O3 -march=native -funroll-loops -ftree-vectorize -ffast-math -ftree-vectorizer-verbose=2  -DENABLE_SNIPER \
-          -I$(SNIPER_INC)
+CFLAGS_O  = -g -O3 -march=native -funroll-loops -ftree-vectorize -ffast-math -ftree-vectorizer-verbose=2 -static \
+           -DENABLE_SNIPER -I$(SNIPER_INC)
 
 LDFLAGS = -L$(SNIPER_LIB) -lsim_api
 

--- a/profiling_container/syntetic/synthetic_char.c
+++ b/profiling_container/syntetic/synthetic_char.c
@@ -46,6 +46,7 @@ void freq_kernel_p(uint64_t iters, uint64_t N, uint64_t stride)
             for (uint64_t i = offset; i < N; i += stride) {
                 a[i] = b[i] * c[i] + a[i];
             }
+        }
     }
     SimRoiEnd();
     printf("ROI_END\n");

--- a/profiling_container/syntetic/synthetic_char.c
+++ b/profiling_container/syntetic/synthetic_char.c
@@ -19,7 +19,6 @@
 
 #include <stdint.h>
 #include <stdlib.h>
-#define SIZE_N 1000
 
 volatile double sink_p;
 
@@ -27,7 +26,7 @@ volatile double sink_p;
  * Compute-bound frequency-scaling kernel - Parallel
  * ------------------------------------------------- */
 
-void freq_kernel_p(uint64_t iters, uint64_t N)
+void freq_kernel_p(uint64_t iters, uint64_t N, uint64_t stride)
 {
     double *a = malloc(N * sizeof(double));
     double *b = malloc(N * sizeof(double));
@@ -39,15 +38,17 @@ void freq_kernel_p(uint64_t iters, uint64_t N)
         b[i] = 2.2;
         c[i] = 3.3;
     }
-	printf("ROI_START\n");
+    printf("ROI_START\n");
     SimRoiStart();
     for (uint64_t iter = 0; iter < iters; iter++) {
-        for (uint64_t i = 0; i < N; i++) {
-            a[i] = b[i] * c[i] + a[i];
-        }
+        // traverse the arrays multiple times using different offset, to reduce spatial locality
+        for (uint64_t offset = 0; offset < stride; offset++) {
+            for (uint64_t i = offset; i < N; i += stride) {
+                a[i] = b[i] * c[i] + a[i];
+            }
     }
     SimRoiEnd();
-	printf("ROI_END\n");
+    printf("ROI_END\n");
 
     // Prevent optimization
     double sum = 0.0;
@@ -70,7 +71,7 @@ void freq_kernel(uint64_t iters)
 {
     double a = 1.1, b = 2.2, c = 3.3;
 
-	printf("ROI_START\n");
+    printf("ROI_START\n");
     SimRoiStart();
     for (uint64_t i = 0; i < iters; i++) {
         a = a * b + c;
@@ -78,7 +79,7 @@ void freq_kernel(uint64_t iters)
         c = c * a + b;
     }
     SimRoiEnd();
-	printf("ROI_END\n");
+    printf("ROI_END\n");
 
     sink = a + b + c;
 }
@@ -130,7 +131,7 @@ int main(int argc, char **argv)
         freq_kernel(iters);
     }
     else if (!strcmp(mode, "freq_p")) {
-        freq_kernel_p(iters,SIZE_N);
+        freq_kernel_p(iters, ws, stride);
     }
     else if (!strcmp(mode, "cache")) {
         uint64_t *array = aligned_alloc(64, ws * sizeof(uint64_t));


### PR DESCRIPTION
- Use size and stride from command line for freq_p kernel
- In freq_p kernel, traverse the arrays multiple times with same stride and different offset each time, this will visit all elements in the array, with less local locality
- replace tab with 4 spaces
- use static linking